### PR TITLE
Update Koios readiness status

### DIFF
--- a/gitbook/plomin-upgrade/chang-upgrade-2-readiness.md
+++ b/gitbook/plomin-upgrade/chang-upgrade-2-readiness.md
@@ -136,7 +136,7 @@ Tooling readiness is supported from version Node 10.1.1 compatible releases. Whe
 
 **Higher Level Tooling**
 
-<table><thead><tr><th width="284">Tools</th><th width="214">Status</th><th>Notes</th></tr></thead><tbody><tr><td>Blockfrost</td><td></td><td>(<a href="https://github.com/blockfrost">repository</a>)</td></tr><tr><td>Koios</td><td></td><td>(<a href="https://github.com/cardano-community/koios-artifacts/releases">release repository</a>)</td></tr><tr><td>Maestro</td><td></td><td>(<a href="https://github.com/maestro-org">repository</a>)</td></tr></tbody></table>
+<table><thead><tr><th width="284">Tools</th><th width="214">Status</th><th>Notes</th></tr></thead><tbody><tr><td>Blockfrost</td><td></td><td>(<a href="https://github.com/blockfrost">repository</a>)</td></tr><tr><td>Koios</td><td><mark style="color:green;">Ready</mark></td><td>(<a href="https://github.com/cardano-community/koios-artifacts/releases">release repository</a>)</td></tr><tr><td>Maestro</td><td></td><td>(<a href="https://github.com/maestro-org">repository</a>)</td></tr></tbody></table>
 
 ***
 


### PR DESCRIPTION
## List of changes

- Update status readiness for Koios (1.3.0 was patched to use node 10.1.3 and dbsync 13.6.0.4)